### PR TITLE
Harden SSH moduli

### DIFF
--- a/salt/sshd/init.sls
+++ b/salt/sshd/init.sls
@@ -7,6 +7,12 @@ generate rsa key:
     - require:
       - pkg: sshd
 
+purge moduli:
+  cmd.run:
+    - name: |
+        awk '$5 > 2000' /etc/ssh/moduli > /tmp/moduli
+        test -s /tmp/moduli && mv /tmp/moduli /etc/ssh/moduli
+        
 authorized_keys:
   file.managed:
     - source: salt://sshd/authorized_keys


### PR DESCRIPTION
As explained on README, we are using hardened SSH config from:

https://stribika.github.io/2015/01/04/secure-secure-shell.html

With this patch we also harden SSH moduli as described above.
