### PR TITLE
Set minion to be masterless

### DIFF
--- a/salt/masterless-minion/init.sls
+++ b/salt/masterless-minion/init.sls
@@ -1,0 +1,11 @@
+set masterless minion:
+  file.append:
+    - name: /etc/salt/minion
+    - text: "file_client: local"
+
+salt-minion:
+  service:
+    - running
+    - enable: True
+    - watch:
+      - file: /etc/salt/minion

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -1,6 +1,7 @@
 base:
   '*':
     - base-system
+    - masterless-minion
     - sshd
     - networking
     - ufw


### PR DESCRIPTION
To avoid cluttering of /var/log/daemon.log with salt-minion
trying to contact salt-master, we declare our minion
as a masterless minion (in fact, we do not have a master
and all files are local to the minion).
