### PR TITLE
Updated README to set locale and timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ ssh pi@raspberrypi.local # password is raspberry
 sudo raspi-config
 # expand filesystem
 # change password
+# i18n options -> change locale (personal preference: en-US.UTF-8)
+# i18n options -> change timezone
 # finish and reboot
 
 echo deb http://debian.saltstack.com/debian jessie-saltstack main | sudo tee --append /etc/apt/sources.list


### PR DESCRIPTION
Without this config, you'll end up having this in your log:

locale: Cannot set LC_CTYPE to default locale: No such file or directory
locale: Cannot set LC_MESSAGES to default locale: No such file or directory
locale: Cannot set LC_ALL to default locale: No such file or directory

You don't want them cluttering your syslog, right?
