### PR TITLE
mumble support improvements

### DIFF
--- a/salt/ufw/lib_ufw/user.rules
+++ b/salt/ufw/lib_ufw/user.rules
@@ -29,7 +29,7 @@
 ### tuple ### allow tcp 22 0.0.0.0/0 any 0.0.0.0/0 in_tun0
 -A ufw-user-input -i tun0 -p tcp --dport 22 -j ACCEPT
 
-### tuple ### allow tcp 64378 0.0.0.0/0 any 0.0.0.0/0 in_tun0
+### tuple ### allow udp 64378 0.0.0.0/0 any 0.0.0.0/0 in_tun0
 -A ufw-before-input -i tun0 -p udp --sport 64738 -j ACCEPT
 
 ### END RULES ###

--- a/salt/ufw/lib_ufw/user.rules
+++ b/salt/ufw/lib_ufw/user.rules
@@ -29,6 +29,9 @@
 ### tuple ### allow tcp 22 0.0.0.0/0 any 0.0.0.0/0 in_tun0
 -A ufw-user-input -i tun0 -p tcp --dport 22 -j ACCEPT
 
+### tuple ### allow tcp 64378 0.0.0.0/0 any 0.0.0.0/0 in_tun0
+-A ufw-before-input -i tun0 -p udp --sport 64738 -j ACCEPT
+
 ### END RULES ###
 
 ### LOGGING ###


### PR DESCRIPTION
This rule will allow UDP packets from mumble server to the internal network.
WIthout this rule, if you connect to a Mumble server your syslog will end up having multiple lines like:

Dec 21 14:40:29 rpi kernel: [96090.534047] [UFW BLOCK] IN=tun0 OUT= MAC= SRC=x DST=x LEN=38 TOS=0x00 PREC=0xE0 TTL=62 ID=39414 DF PROTO=UDP SPT=64738 DPT=54857 LEN=18

and Mumble application will switch to TCP mode due to UDP unreachability.

This patch allows Mumble UDP connections.