### PR TITLE
Feat: Prefer ed25519 ssh keys over rsa

### DIFF
--- a/salt/sshd/init.sls
+++ b/salt/sshd/init.sls
@@ -1,9 +1,10 @@
 generate rsa key:
   cmd.run:
     - name: |
-        rm /etc/ssh/ssh_host_rsa_key &&
-        ssh-keygen -t rsa -b 4096 -N '' -f /etc/ssh/ssh_host_rsa_key
-    - unless: openssl rsa -text -noout -in /etc/ssh/ssh_host_rsa_key | grep "4096 bit"
+        cd /etc/ssh && rm ssh_host_*key*
+        ssh-keygen -t ed25519 -f ssh_host_ed25519_key < /dev/null
+        ssh-keygen -t rsa -b 4096 -f ssh_host_rsa_key < /dev/null
+    - unless: openssl rsa -text -noout -in /etc/ssh/ssh_host_rsa_key | grep "4096 bit" && test -f /etc/ssh/ssh_host_ed25519_key
     - require:
       - pkg: sshd
 

--- a/salt/sshd/sshd_config
+++ b/salt/sshd/sshd_config
@@ -8,6 +8,7 @@ Port 22
 #ListenAddress 0.0.0.0
 Protocol 2
 # HostKeys for protocol version 2
+HostKey /etc/ssh/ssh_host_ed25519_key
 HostKey /etc/ssh/ssh_host_rsa_key
 
 # Disable weak crypto - https://presentations.nordisch.org/olddognewtricks/#/


### PR DESCRIPTION
Following https://stribika.github.io/2015/01/04/secure-secure-shell.html , ed25519 should be preferrable over RSA.