### PR TITLE
Revert "Use rsync to transfer and clean up sls"

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ sudo chown -R pi /srv
 Now copy configuration files from this project onto the Raspberry Pi:
 
 ```
-rsync -e ssh -avz --progress --delete --exclude=.git . pi@raspberrypi.local://srv
+scp -r . pi@raspberrypi.local://srv
 ```
 
 Run Salt to configure it and finally reboot:


### PR DESCRIPTION
Reverts moio/raspberry-openvpn-gateway#12

Since rsync is not installed by default on raspberry, you'll end up with this error:

https://superuser.com/questions/105837/rsync-over-ssh-or-something-else
