### PR TITLE
Feat: get rid of 'pi' user, enable user-configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ Now change your network cables to the configuration above, done!
 
 ## Post-install access
 
+A personal user has been created as you defined in `pillar/config.sls`. Password for
+this user has been set to `changeme`. Upon the first connection, (remember to use your SSH key that you copied in `salt/sshd/authorized_keys`), you will be asked to
+change it.
+
 SSH is configured to accept connections on port 22. Note that security settings are [tuned as per recent recommended standards](https://stribika.github.io/2015/01/04/secure-secure-shell.html), including the fact that the RSA key is regenerated with key length 4096 bits, so you will get warnings on first connection attempt.
 
 ## Tweaking

--- a/pillar/config.sls
+++ b/pillar/config.sls
@@ -1,7 +1,9 @@
 hostname: raspberrypi
 domain: moio
 # additional_search_domains: mycompany.example, myothercompany.example
-# locale: en_US
-# additional_locale: en_GB
-# timezone: Europe/Rome
-# preferred_raspbian_mirror: http://raspbian.mirror.garr.it/mirrors/raspbian/raspbian/
+locale: en_US
+additional_locale: en_GB
+timezone: Europe/Rome
+preferred_raspbian_mirror: http://raspbian.mirror.garr.it/mirrors/raspbian/raspbian/
+user_name: user
+user_real_name: User

--- a/salt/base-system/init.sls
+++ b/salt/base-system/init.sls
@@ -1,6 +1,7 @@
 include:
   - base-system.locale
   - base-system.timezone
+  - base-system.non-root-user
 
 hosts-file:
   file.replace:

--- a/salt/base-system/non-root-user/init.sls
+++ b/salt/base-system/non-root-user/init.sls
@@ -1,0 +1,46 @@
+user-creation:
+  user.present:
+    - name: {{ salt['pillar.get']('user_name', 'user') }}
+    - password: $1$LioLpkU4$3HYx.bRJmq79nCZcvyoDw1 # changeme
+    - enforce_password: False
+    - gid: users
+    - fullname: {{ salt['pillar.get']('user_real_name', 'User') }}
+    - shell: /bin/bash
+    - groups:
+      - sudo
+      - adm
+      - dialout
+      - cdrom
+      - audio
+      - video
+      - plugdev
+      - games
+      - input
+      - netdev
+      - spi
+      - i2c
+      - gpio
+
+user-creation-force-password-change:
+  cmd.run:
+    - name: "chage -d 0 {{ salt['pillar.get']('user_name') }}"
+    - onchanges:
+      - user: user-creation
+
+/srv:
+  file.directory:
+    - user: {{ salt['pillar.get']('user_name', 'user') }}
+    - group: users
+    - recurse:
+       - user
+       - group
+    - onchanges:
+      - user: user-creation
+
+pi-user-deletion:
+  user.absent:
+    - name: pi
+    - purge: True
+    - force: True
+  require:
+    - sls: sshd

--- a/salt/sshd/sshd_config
+++ b/salt/sshd/sshd_config
@@ -94,7 +94,7 @@ Subsystem sftp /usr/lib/openssh/sftp-server
 # If you just want the PAM account and session checks to run without
 # PAM authentication, then enable this but set PasswordAuthentication
 # and ChallengeResponseAuthentication to 'no'.
-UsePAM no
+UsePAM yes
 
 ClientAliveInterval 30
 ClientAliveCountMax 10


### PR DESCRIPTION
'pi' user is a well known user for attacks.
This PR removes it while offers a user-configurable user that is
created the first time this Salt state is applied.
See pillar/config.sls and README.md